### PR TITLE
Use useOutletContext for child route, and use types for Launches

### DIFF
--- a/app/routes/missions.tsx
+++ b/app/routes/missions.tsx
@@ -1,4 +1,5 @@
-import {Form, Outlet, useLoaderData, useParams} from 'remix';
+import {Form, Outlet, useLoaderData, useOutletContext, useParams} from 'remix';
+import { Launch } from '~/types';
 
 import MissionListFeature, { links as MissionListFeatureStyles } from '../features/missions/mission-list.feature';
 
@@ -18,6 +19,10 @@ export async function loader({ request }) {
   }
 
   return res;
+}
+
+export function useLaunches() {
+  return useOutletContext<Launch>();
 }
 
 export default function Index() {
@@ -42,7 +47,7 @@ export default function Index() {
           <MissionListFeature missions={loaderData} />
         </div>
         <div className="page__detail">
-          {slug ? (<Outlet />) : (<div>
+          {slug ? (<Outlet context={loaderData.find((element) => element?.name === slug)} />) : (<div>
             <p>No mission selected</p>
           <img src="/assets/elon.jpg" alt="" />
 

--- a/app/routes/missions/$slug.tsx
+++ b/app/routes/missions/$slug.tsx
@@ -1,20 +1,7 @@
-import {useLoaderData} from 'remix';
-
-export async function loader({params}) {
-  const slug = params.slug;
-
-  let res = await fetch('https://api.spacexdata.com/v4/launches');
-  res = await res.json();
-
-  if (slug) {
-    return res.find((element) => element?.name === slug);
-  } else {
-    return null;
-  }
-}
+import { useLaunches } from '../missions';
 
 export default function MissionSlug() {
-  const loaderData = useLoaderData() || null;
+  const loaderData = useLaunches() || null;
 
   console.log(loaderData);
   return (

--- a/app/types.d.ts
+++ b/app/types.d.ts
@@ -1,0 +1,82 @@
+export interface Fairings {
+  reused: boolean;
+  recovery_attempt: boolean;
+  recovered: boolean;
+  ships: any[];
+}
+
+export interface Patch {
+  small: string;
+  large: string;
+}
+
+export interface Reddit {
+  campaign?: any;
+  launch?: any;
+  media?: any;
+  recovery?: any;
+}
+
+export interface Flickr {
+  small: any[];
+  original: any[];
+}
+
+export interface Links {
+  patch: Patch;
+  reddit: Reddit;
+  flickr: Flickr;
+  presskit?: any;
+  webcast: string;
+  youtube_id: string;
+  article: string;
+  wikipedia: string;
+}
+
+export interface Failure {
+  time: number;
+  altitude?: any;
+  reason: string;
+}
+
+export interface Core {
+  core: string;
+  flight: number;
+  gridfins: boolean;
+  legs: boolean;
+  reused: boolean;
+  landing_attempt: boolean;
+  landing_success?: any;
+  landing_type?: any;
+  landpad?: any;
+}
+
+export interface Launch {
+  fairings: Fairings;
+  links: Links;
+  static_fire_date_utc: Date;
+  static_fire_date_unix: number;
+  net: boolean;
+  window: number;
+  rocket: string;
+  success: boolean;
+  failures: Failure[];
+  details: string;
+  crew: any[];
+  ships: any[];
+  capsules: any[];
+  payloads: string[];
+  launchpad: string;
+  flight_number: number;
+  name: string;
+  date_utc: Date;
+  date_unix: number;
+  date_local: Date;
+  date_precision: string;
+  upcoming: boolean;
+  cores: Core[];
+  auto_update: boolean;
+  tbd: boolean;
+  launch_library_id?: any;
+  id: string;
+}


### PR DESCRIPTION
This change prevents loading data twice, on the Missions page, and in the detail page.
And adds type definition for Launches